### PR TITLE
Fix item type so Safari on iOS 16 can render images

### DIFF
--- a/mp4.go
+++ b/mp4.go
@@ -725,7 +725,7 @@ func muxFrame(w io.Writer, m image.Image, subsampling image.YCbCrSubsampleRatio,
 
 	fileData := boxMDAT{data: obuData}
 	fileType := boxFTYP{
-		majorBrand:       itemTypeMIF1,
+		majorBrand:       itemTypeAVIF,
 		compatibleBrands: []fourCC{itemTypeMIF1, itemTypeAVIF, itemTypeMIAF},
 	}
 	metadata := boxMETA{


### PR DESCRIPTION
This was incorrectly identifying the image as a HEIF image when it was in fact an AVIF image.

Signed-off-by: Xe <me@xeiaso.net>